### PR TITLE
Explicitly specified the compatible openvino library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gdown==3.12.2
 numpy
 opencv-python
-openvino
+openvino==2021.4.2
 blessed


### PR DESCRIPTION
The latest openvino library 2022.x version is incompatible with this library. Hence updated the requirements file to specify the last compatible version of openvino library. Now the error is fixed and the library is working properly.

More details are in https://github.com/bes-dev/random_face/issues/6
